### PR TITLE
Fix `open_loop': redirection forbidden

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -7,7 +7,7 @@ def clean_whitespace(a)
   a.gsub(/[\r\n\t]/, ' ').squeeze(" ").strip
 end
 
-base_url = 'http://planning.mackay.qld.gov.au/masterview/Modules/Applicationmaster/'
+base_url = 'https://planning.mackay.qld.gov.au/masterview/Modules/Applicationmaster/'
 url = "#{base_url}default.aspx?page=found&1=thisweek" # add &6=T to see determined
 doc = Nokogiri::HTML(open(url))
 das = doc.xpath("//a[contains(@href,'&key=')]").collect do |approval_anchor|


### PR DESCRIPTION
Fixes

```
/app/vendor/ruby-1.9.3/lib/ruby/1.9.1/open-uri.rb:216:in `open_loop': redirection forbidden: http://planning.mackay.qld.gov.au/masterview/Modules/Applicationmaster/default.aspx?page=found&1=thisweek -> https://planning.mackay.qld.gov.au/MasterView/Modules/Applicationmaster/default.aspx?page=found&1=thisweek (RuntimeError)
    from /app/vendor/ruby-1.9.3/lib/ruby/1.9.1/open-uri.rb:146:in `open_uri'
    from /app/vendor/ruby-1.9.3/lib/ruby/1.9.1/open-uri.rb:678:in `open'
    from /app/vendor/ruby-1.9.3/lib/ruby/1.9.1/open-uri.rb:33:in `open'
    from scraper.rb:12:in `<main>'
```
